### PR TITLE
SSL: added ENGINE_init() call before loading key.

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -727,16 +727,21 @@ ngx_ssl_load_certificate_key(ngx_pool_t *pool, char **err,
             return NULL;
         }
 
+        if (!ENGINE_init(engine)) {
+            *err = "ENGINE_init() failed";
+            ENGINE_free(engine);
+            return NULL;
+        }
+
         *last++ = ':';
 
         pkey = ENGINE_load_private_key(engine, (char *) last, 0, 0);
 
         if (pkey == NULL) {
             *err = "ENGINE_load_private_key() failed";
-            ENGINE_free(engine);
-            return NULL;
         }
 
+        ENGINE_finish(engine);
         ENGINE_free(engine);
 
         return pkey;


### PR DESCRIPTION
It is necessary to call ENGINE_init() before using an OpenSSL engine
to get the engine functional reference.  Without this, when
ENGINE_load_private_key() is called, the engine is still uninitialized.